### PR TITLE
added param missing in comments for apidoc

### DIFF
--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -9,6 +9,8 @@ module.exports = (() => {
 	* @apiName GetUserIdByEmail
 	* @apiGroup User
 	*
+	* @apiParam {String} email User email.
+	*
 	* @apiHeader {String} token Authorization Bearer Token.
 	*
 	* @apiSuccess {Number} id User ID.


### PR DESCRIPTION
Small typo:
- missing `email` param in the comments for `GET /user/:email` endpoint for `apidoc` 