### PR TITLE
updated queries so no need to use .map for GET /chat/:cid

### DIFF
--- a/src/controllers/chat.controller.js
+++ b/src/controllers/chat.controller.js
@@ -89,21 +89,7 @@ exports.getUserChats = async (req, res, next) => {
 exports.getMessagesInChat = async (req, res, next) => {
     try {
         // get messages by chat id inc user info
-        const resp = await db.any(queries.findMessagesByChatId, [req.params.cid]);
-
-        // shape returned data with message id, text, created_at
-        // and user info obj 
-        const messages = resp.map(({ users_id, id, chats_id, text, created_at, ...userWithPw}) => {
-            const { password, ...user } = userWithPw;
-            user.id = users_id; // tack on user id
-            
-            return {
-                id,
-                text,
-                created_at,
-                user
-            };
-        });
+        const messages = await db.any(queries.findMessagesByChatId, [req.params.cid]);
 
         // success; return array of messages
         return res.status(200).json(messages);

--- a/src/db/queries.js
+++ b/src/db/queries.js
@@ -56,6 +56,7 @@ module.exports = {
             created_at,
             json_build_object(
                 'id', users.id, 
+                'email', users.email,
                 'display_name', users.display_name,
                 'first_name', users.first_name,
                 'last_name', users.last_name

--- a/src/db/queries.js
+++ b/src/db/queries.js
@@ -27,7 +27,8 @@ module.exports = {
             name, 
             json_agg(
                 json_build_object(
-                    'id', users_id, 'display_name', display_name
+                    'id', users_id, 
+                    'display_name', display_name
                 )
             ) AS users 
         FROM users_chats AS uc 
@@ -50,9 +51,15 @@ module.exports = {
     createMessage: new PS('create-message', 'INSERT INTO messages(chats_id, users_id, text) VALUES($1, $2, $3)'),
     findMessagesByChatId: new PS('find-messages-by-chat-id', 
         `SELECT 
-            users.id AS users_id, 
-            users.*, 
-            messages.* 
+            messages.id,
+            text,
+            created_at,
+            json_build_object(
+                'id', users.id, 
+                'display_name', users.display_name,
+                'first_name', users.first_name,
+                'last_name', users.last_name
+            ) AS user
         FROM messages 
         INNER JOIN users ON users.id=users_id 
         WHERE chats_id = $1`


### PR DESCRIPTION
Thought using `map` was a bit more expensive than necessary to get the message information and user information for each message. Adjusted queries so no need to use `map`.