### PR TITLE
updated resp of GET /chat/:cid

### DIFF
--- a/src/db/queries.js
+++ b/src/db/queries.js
@@ -52,17 +52,10 @@ module.exports = {
     findMessagesByChatId: new PS('find-messages-by-chat-id', 
         `SELECT 
             messages.id,
-            text,
+            users_id,
             created_at,
-            json_build_object(
-                'id', users.id, 
-                'email', users.email,
-                'display_name', users.display_name,
-                'first_name', users.first_name,
-                'last_name', users.last_name
-            ) AS user
+            text
         FROM messages 
-        INNER JOIN users ON users.id=users_id 
         WHERE chats_id = $1`
     ),
 }

--- a/src/routes/chats.js
+++ b/src/routes/chats.js
@@ -105,39 +105,24 @@ module.exports = (() => {
 	*
 	* @apiSuccess {Object[]} - List of messages.
 	* @apiSuccess {Number} -.id Message id.
+	* @apiSuccess {Number} -.users_id User ID of user who posted message.
+	* @apiSuccess {String} -.created_at Message timestamp with timezone; defaults to current.
 	* @apiSuccess {String} -.text Message text.
-	* @apiSuccess {Object} -.user User information.
- 	* @apiSuccess {Number} -.user.id User ID.
- 	* @apiSuccess {String} -.user.display_name User display name.
- 	* @apiSuccess {String} -.user.first_name User first name.
- 	* @apiSuccess {String} -.user.last_name User last name.
 	*
 	* @apiSuccessExample Success Response:
 	*     HTTP/1.1 200 OK
 	*     [
  	*          {
 	*               "id": 4,
-	*               "text": "here's a message",
+	*               "users_id": 2,
 	*               "created_at": "2019-05-04T00:31:35.880Z",
-	*               "user": {
-	*                    "id": 2,
-	*                    "email": "test123@yahoo.com",
-	*                    "display_name": "bob",
-	*                    "first_name": "bob",
-	*                    "last_name": "bob"
-	*               }
+	*               "text": "here's a message"
 	*          },
 	*          {
 	*               "id": 2,
-	*               "text": "here's another message",
+	*               "users_id": 1,
 	*               "created_at": "2019-05-03T23:33:41.659Z",
-	*               "user": {
-	*                    "id": 1,
-	*                    "email": "test123@gmail.com",
-	*                    "display_name": "manos",
-	*                    "first_name": null,
-	*                    "last_name": null
-	*               }
+	*               "text": "here's another message"
 	*          }
  	*     ]
 	*

--- a/test/chat.test.js
+++ b/test/chat.test.js
@@ -171,13 +171,7 @@ describe('Test Suite for chat', () => {
                     id: 1,
                     text: 'hey',
                     created_at: '2019-05-06T14:35:24.848Z',
-                    user: { 
-                            id: 1,
-                            email: 'user@gmail.com',
-                            display_name: 'manos',
-                            first_name: null,
-                            last_name: null 
-                        } 
+                    users_id: 1
                 } 
             ]
         */
@@ -185,13 +179,9 @@ describe('Test Suite for chat', () => {
             expect.arrayContaining([
                 expect.objectContaining({
                     id: 1,
+                    users_id: 1,
                     text: 'hey',
-                    created_at: expect.any(String),
-                    user: expect.objectContaining({
-                        id: 1,
-                        email,
-                        display_name
-                    })
+                    created_at: expect.any(String)
                 })
             ])
         );


### PR DESCRIPTION
`GET /chat/:cid` updated (change is **in bold** below); returns array of message objects that each include:
- `id`: message id
- **`users_id`: user id of user who posted message** (instead of user object) 
- `created_at`: message timestamp with timezone
- `text`: message text

This was a change made in discussion with @mnicole about what would be best practice/standard.

@ernewtoner, this will require updating the redux store, such that - since you're maintaining a list of users in the **chat** information, you can match them up to the **message** information.

As suggested by Michele, one way to do that might be: in the reducer after getting the chats or messages info, you can update the chat info so it's formatted like so (notice how you're updating the `users` array so it's an object and the key to each user object is their user id and the value is a key-value pair for the user `name` - this ensures you have efficient, i.e. constant, lookup time for each user):
```
{ 
    id: 1, 
    name: 'my chat', 
    users: {
        1: { name: 'michele' }, 
        2: { name: 'sonam' }
    }
}
```